### PR TITLE
Add base archiso content, build script, Dockerfile, and docs updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# сборочные каталоги archiso
+work/
+out/
+archflux/
+
+# временные файлы
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM archlinux:base
+
+RUN pacman -Syu --noconfirm archiso git sudo bash \
+    && pacman -Scc --noconfirm
+
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN chmod +x /workspace/scripts/build.sh
+
+ENTRYPOINT ["bash", "/workspace/scripts/build.sh"]

--- a/README.md
+++ b/README.md
@@ -1,34 +1,39 @@
-#!/usr/bin/env bash
-set -euo pipefail
+# ArchFlux OS — сборка live-ISO
 
-# Скрипт: build.sh
-# Требования: запустите на Arch Linux или в контейнере с pacman (root/возможность sudo).
-# Устанавливает archiso при необходимости, создаёт профиль ArchFlux и собирает ISO.
+Этот репозиторий содержит заготовку для сборки Arch-based live ISO (ArchFlux OS) через `archiso`.
 
-PROFILE_NAME="archflux"
-WORKDIR="$PWD/work"
-OUTDIR="$PWD/out"
-SRCTEMPLATE="/usr/share/archiso/configs/releng"
+## Быстрый старт (локально)
 
-if ! command -v mkarchiso >/dev/null 2>&1; then
-  echo "archiso не найден. Устанавливаю..."
-  sudo pacman -S --needed archiso
-fi
+1. Убедитесь, что вы на Arch Linux (или в среде с `pacman`).
+2. Запустите скрипт сборки:
 
-# Подготовка рабочей копии профиля
-rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
-cp -r "$SRCTEMPLATE" "$PROFILE_NAME"
+```bash
+./scripts/build.sh
+```
 
-# Подменяем packages.x86_64 на наш
-cp packages.x86_64 "$PROFILE_NAME"/packages.x86_64
+Скрипт автоматически установит `archiso` при необходимости и соберёт ISO в директорию `out/`.
 
-# Копируем airootfs overlay (директория с конфигами для live-окружения)
-rm -rf "$PROFILE_NAME"/airootfs
-cp -r airootfs "$PROFILE_NAME"/airootfs
+## Сборка в Docker
 
-# Опционально: добавьте свои файлы в isolinux/efi, загрузочные скрипты и др.
+Для воспроизводимого окружения можно собрать ISO в контейнере:
 
-echo "Запускаю сборку ISO (mkarchiso)..."
-sudo mkarchiso -v -w "$WORKDIR" -o "$OUTDIR" "$PROFILE_NAME"
+```bash
+docker build -t archflux-builder .
+```
 
-echo "Готово. Результат в: $OUTDIR"
+Запуск сборки:
+
+```bash
+docker run --rm -v "$(pwd)":/workspace archflux-builder
+```
+
+> Важно: контейнер использует `archiso`, поэтому необходим доступ к `pacman` зеркалам.
+
+## Настройка содержимого ISO
+
+- `packages.x86_64` — список пакетов, который будет использован при сборке (в репозитории есть минимальный набор).
+- `airootfs/` — overlay директории, которые попадут в live-окружение (пример: `airootfs/etc/hostname`).
+
+## Полезные материалы
+
+Список задач и план работ расположен в каталоге [`projects/`](projects/).

--- a/airootfs/etc/hostname
+++ b/airootfs/etc/hostname
@@ -1,0 +1,1 @@
+archflux

--- a/airootfs/etc/motd
+++ b/airootfs/etc/motd
@@ -1,0 +1,3 @@
+ArchFlux OS live environment
+
+Данные в live-среде не сохраняются после перезагрузки.

--- a/airootfs/root/.bashrc
+++ b/airootfs/root/.bashrc
@@ -1,0 +1,2 @@
+# ArchFlux OS live shell
+alias ll='ls -alF'

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -1,0 +1,15 @@
+# Базовые пакеты ArchFlux OS (минимальный live-набор)
+base
+linux
+linux-firmware
+mkinitcpio
+systemd
+bash
+coreutils
+util-linux
+iproute2
+iputils
+openssh
+networkmanager
+nano
+vim

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Скрипт: build.sh
+# Требования: запуск на Arch Linux или в контейнере с pacman.
+# Устанавливает archiso при необходимости, создаёт профиль ArchFlux и собирает ISO.
+
+PROFILE_NAME="${PROFILE_NAME:-archflux}"
+WORKDIR="${WORKDIR:-$PWD/work}"
+OUTDIR="${OUTDIR:-$PWD/out}"
+SRCTEMPLATE="${SRCTEMPLATE:-/usr/share/archiso/configs/releng}"
+
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+if ! command -v mkarchiso >/dev/null 2>&1; then
+  echo "archiso не найден. Устанавливаю..."
+  $SUDO pacman -S --needed --noconfirm archiso
+fi
+
+# Подготовка рабочей копии профиля
+rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
+cp -r "$SRCTEMPLATE" "$PROFILE_NAME"
+
+# Подменяем packages.x86_64 на наш (если существует)
+if [[ -f "packages.x86_64" ]]; then
+  cp packages.x86_64 "$PROFILE_NAME"/packages.x86_64
+fi
+
+# Копируем airootfs overlay (директория с конфигами для live-окружения)
+if [[ -d "airootfs" ]]; then
+  rm -rf "$PROFILE_NAME"/airootfs
+  cp -r airootfs "$PROFILE_NAME"/airootfs
+fi
+
+# Опционально: добавьте свои файлы в isolinux/efi, загрузочные скрипты и др.
+
+echo "Запускаю сборку ISO (mkarchiso)..."
+$SUDO mkarchiso -v -w "$WORKDIR" -o "$OUTDIR" "$PROFILE_NAME"
+
+echo "Готово. Результат в: $OUTDIR"


### PR DESCRIPTION
### Motivation
- Provide a minimal, ready-to-use repository layout to build an Arch-based live ISO (ArchFlux) using `archiso` so the project can be built locally or in CI/containers. 
- Include a reproducible Docker-based build path and a portable build script to simplify developer and CI workflows. 
- Add sensible defaults and starter overlays so the repository is usable out of the box for further customization.

### Description
- Add a minimal package list in `packages.x86_64` with a small set of base live packages. 
- Add starter `airootfs` overlays: `airootfs/etc/hostname`, `airootfs/etc/motd`, and `airootfs/root/.bashrc` to populate the live environment. 
- Add a portable build helper `scripts/build.sh` that auto-installs `archiso` if missing, prepares an archiso profile from `SRCTEMPLATE`, applies `packages.x86_64` and `airootfs/` overlays when present, and runs `mkarchiso` to produce the ISO in `out/`; the script respects environment overrides (`PROFILE_NAME`, `WORKDIR`, `OUTDIR`, `SRCTEMPLATE`). 
- Add a `Dockerfile` that installs `archiso`, copies the repository to `/workspace`, makes the build script executable, and invokes the build script to enable containerized builds. 
- Add `.gitignore` entries to ignore generated `work/`, `out/`, and `archflux/` build directories and temporary logs. 
- Update `README.md` with quick-start instructions for local and Docker builds and document the `packages.x86_64` and `airootfs/` inputs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983114a5a78832596b8ac623e938aa3)