### PR TITLE
Add bootloader configs, ISO profile, and integrate with build script/README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# сборочные каталоги archiso
+work/
+out/
+archflux/
+
+# временные файлы
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM archlinux:base
+
+RUN pacman -Syu --noconfirm archiso git sudo bash \
+    && pacman -Scc --noconfirm
+
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN chmod +x /workspace/scripts/build.sh
+
+ENTRYPOINT ["bash", "/workspace/scripts/build.sh"]

--- a/README.md
+++ b/README.md
@@ -1,34 +1,41 @@
-#!/usr/bin/env bash
-set -euo pipefail
+# ArchFlux OS — сборка live-ISO
 
-# Скрипт: build.sh
-# Требования: запустите на Arch Linux или в контейнере с pacman (root/возможность sudo).
-# Устанавливает archiso при необходимости, создаёт профиль ArchFlux и собирает ISO.
+Этот репозиторий содержит заготовку для сборки Arch-based live ISO (ArchFlux OS) через `archiso`.
 
-PROFILE_NAME="archflux"
-WORKDIR="$PWD/work"
-OUTDIR="$PWD/out"
-SRCTEMPLATE="/usr/share/archiso/configs/releng"
+## Быстрый старт (локально)
 
-if ! command -v mkarchiso >/dev/null 2>&1; then
-  echo "archiso не найден. Устанавливаю..."
-  sudo pacman -S --needed archiso
-fi
+1. Убедитесь, что вы на Arch Linux (или в среде с `pacman`).
+2. Запустите скрипт сборки:
 
-# Подготовка рабочей копии профиля
-rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
-cp -r "$SRCTEMPLATE" "$PROFILE_NAME"
+```bash
+./scripts/build.sh
+```
 
-# Подменяем packages.x86_64 на наш
-cp packages.x86_64 "$PROFILE_NAME"/packages.x86_64
+Скрипт автоматически установит `archiso` при необходимости и соберёт ISO в директорию `out/`.
 
-# Копируем airootfs overlay (директория с конфигами для live-окружения)
-rm -rf "$PROFILE_NAME"/airootfs
-cp -r airootfs "$PROFILE_NAME"/airootfs
+## Сборка в Docker
 
-# Опционально: добавьте свои файлы в isolinux/efi, загрузочные скрипты и др.
+Для воспроизводимого окружения можно собрать ISO в контейнере:
 
-echo "Запускаю сборку ISO (mkarchiso)..."
-sudo mkarchiso -v -w "$WORKDIR" -o "$OUTDIR" "$PROFILE_NAME"
+```bash
+docker build -t archflux-builder .
+```
 
-echo "Готово. Результат в: $OUTDIR"
+Запуск сборки:
+
+```bash
+docker run --rm -v "$(pwd)":/workspace archflux-builder
+```
+
+> Важно: контейнер использует `archiso`, поэтому необходим доступ к `pacman` зеркалам.
+
+## Настройка содержимого ISO
+
+- `packages.x86_64` — список пакетов, который будет использован при сборке (в репозитории есть минимальный набор).
+- `airootfs/` — overlay директории, которые попадут в live-окружение (пример: `airootfs/etc/hostname`).
+- `profiledef.sh` — параметры ISO (label, имя, режимы загрузки).
+- `boot/` — загрузчик (isolinux/systemd-boot) и конфиги для BIOS/UEFI.
+
+## Полезные материалы
+
+Список задач и план работ расположен в каталоге [`projects/`](projects/).

--- a/airootfs/etc/hostname
+++ b/airootfs/etc/hostname
@@ -1,0 +1,1 @@
+archflux

--- a/airootfs/etc/motd
+++ b/airootfs/etc/motd
@@ -1,0 +1,3 @@
+ArchFlux OS live environment
+
+Данные в live-среде не сохраняются после перезагрузки.

--- a/airootfs/root/.bashrc
+++ b/airootfs/root/.bashrc
@@ -1,0 +1,2 @@
+# ArchFlux OS live shell
+alias ll='ls -alF'

--- a/boot/efiboot/loader/entries/archflux.conf
+++ b/boot/efiboot/loader/entries/archflux.conf
@@ -1,0 +1,4 @@
+title   ArchFlux OS Live (x86_64)
+linux   /arch/boot/x86_64/vmlinuz-linux
+initrd  /arch/boot/x86_64/initramfs-linux.img
+options archisobasedir=arch archisolabel=ARCHFLUX quiet

--- a/boot/efiboot/loader/loader.conf
+++ b/boot/efiboot/loader/loader.conf
@@ -1,0 +1,4 @@
+default archflux
+timeout 3
+console-mode max
+editor no

--- a/boot/isolinux/isolinux.cfg
+++ b/boot/isolinux/isolinux.cfg
@@ -1,0 +1,11 @@
+UI menu.c32
+PROMPT 0
+MENU TITLE ArchFlux OS Live
+TIMEOUT 50
+DEFAULT archflux
+
+LABEL archflux
+  MENU LABEL ArchFlux OS Live (x86_64)
+  LINUX /arch/boot/x86_64/vmlinuz-linux
+  INITRD /arch/boot/x86_64/initramfs-linux.img
+  APPEND archisobasedir=arch archisolabel=ARCHFLUX quiet

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -1,0 +1,15 @@
+# Базовые пакеты ArchFlux OS (минимальный live-набор)
+base
+linux
+linux-firmware
+mkinitcpio
+systemd
+bash
+coreutils
+util-linux
+iproute2
+iputils
+openssh
+networkmanager
+nano
+vim

--- a/profiledef.sh
+++ b/profiledef.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+iso_name="ArchFlux-OS"
+iso_label="ARCHFLUX"
+iso_publisher="ArchFlux OS"
+iso_application="ArchFlux OS Live ISO"
+iso_version="$(date +%Y.%m.%d)"
+install_dir="arch"
+bootmodes=('bios.syslinux.mbr' 'bios.syslinux.eltorito' 'uefi-ia32.systemd-boot' 'uefi-x64.systemd-boot')
+arch="x86_64"
+work_dir="work"
+out_dir="out"
+file_permissions=(
+  ["/etc/shadow"]="0:0:400"
+  ["/root"]="0:0:750"
+)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Скрипт: build.sh
+# Требования: запуск на Arch Linux или в контейнере с pacman.
+# Устанавливает archiso при необходимости, создаёт профиль ArchFlux и собирает ISO.
+
+PROFILE_NAME="${PROFILE_NAME:-archflux}"
+WORKDIR="${WORKDIR:-$PWD/work}"
+OUTDIR="${OUTDIR:-$PWD/out}"
+SRCTEMPLATE="${SRCTEMPLATE:-/usr/share/archiso/configs/releng}"
+
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+if ! command -v mkarchiso >/dev/null 2>&1; then
+  echo "archiso не найден. Устанавливаю..."
+  $SUDO pacman -S --needed --noconfirm archiso
+fi
+
+# Подготовка рабочей копии профиля
+rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
+cp -r "$SRCTEMPLATE" "$PROFILE_NAME"
+
+# Подменяем packages.x86_64 на наш (если существует)
+if [[ -f "packages.x86_64" ]]; then
+  cp packages.x86_64 "$PROFILE_NAME"/packages.x86_64
+fi
+
+# Подменяем profiledef.sh (если существует)
+if [[ -f "profiledef.sh" ]]; then
+  cp profiledef.sh "$PROFILE_NAME"/profiledef.sh
+fi
+
+# Копируем airootfs overlay (директория с конфигами для live-окружения)
+if [[ -d "airootfs" ]]; then
+  rm -rf "$PROFILE_NAME"/airootfs
+  cp -r airootfs "$PROFILE_NAME"/airootfs
+fi
+
+# Копируем загрузчики (isolinux/efiboot), если заданы
+if [[ -d "boot/isolinux" ]]; then
+  rm -rf "$PROFILE_NAME"/isolinux
+  cp -r boot/isolinux "$PROFILE_NAME"/isolinux
+fi
+
+if [[ -d "boot/efiboot" ]]; then
+  rm -rf "$PROFILE_NAME"/efiboot
+  cp -r boot/efiboot "$PROFILE_NAME"/efiboot
+fi
+
+# Опционально: добавьте свои файлы в isolinux/efi, загрузочные скрипты и др.
+
+echo "Запускаю сборку ISO (mkarchiso)..."
+$SUDO mkarchiso -v -w "$WORKDIR" -o "$OUTDIR" "$PROFILE_NAME"
+
+echo "Готово. Результат в: $OUTDIR"


### PR DESCRIPTION
### Motivation

- Provide a complete archiso profile including bootloader pieces so the generated ISO can boot on BIOS and UEFI systems. 
- Centralize ISO metadata and boot mode configuration to make builds reproducible and configurable. 
- Integrate bootloader/profile artifacts into the existing build and container workflows for easier local and CI/containerized builds.

### Description

- Add a `profiledef.sh` file with ISO metadata (`iso_name`, `iso_label`, `iso_version`, `bootmodes`, etc.) to drive `archiso` profile settings. 
- Add BIOS and UEFI bootloader configs under `boot/` including `boot/isolinux/isolinux.cfg` and systemd-boot files in `boot/efiboot/loader/` and `boot/efiboot/loader/entries/archflux.conf`. 
- Update `scripts/build.sh` to copy `profiledef.sh` and the `boot/` directory into the generated profile and preserve existing behavior for `packages.x86_64` and `airootfs/`. 
- Include supporting repository artifacts and documentation: add `packages.x86_64` sample package list, `airootfs/` overlays (`/etc/hostname`, `/etc/motd`, `/root/.bashrc`), a `Dockerfile` for containerized builds, and `.gitignore` entries; update `README.md` to document `profiledef.sh` and `boot/` inputs and quick-start build instructions.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983114a5a78832596b8ac623e938aa3)