### PR TITLE
Improve ISO build script options and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@
 
 Скрипт автоматически установит `archiso` при необходимости и соберёт ISO в директорию `out/`.
 
+### Полезные опции
+
+```bash
+./scripts/build.sh --help
+./scripts/build.sh --outdir ./artifacts --workdir ./tmp/work
+./scripts/build.sh --keep-workdir
+```
+
+Переменные окружения (эквивалентны CLI-аргументам):
+- `PROFILE_NAME`
+- `WORKDIR`
+- `OUTDIR`
+- `SRCTEMPLATE`
+- `KEEP_WORKDIR=1`
+
 ## Сборка в Docker
 
 Для воспроизводимого окружения можно собрать ISO в контейнере:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,11 +9,73 @@ PROFILE_NAME="${PROFILE_NAME:-archflux}"
 WORKDIR="${WORKDIR:-$PWD/work}"
 OUTDIR="${OUTDIR:-$PWD/out}"
 SRCTEMPLATE="${SRCTEMPLATE:-/usr/share/archiso/configs/releng}"
+KEEP_WORKDIR="${KEEP_WORKDIR:-0}"
 
 if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
   SUDO=""
 else
   SUDO="sudo"
+fi
+
+usage() {
+  cat <<USAGE
+Usage: ./scripts/build.sh [options]
+
+Options:
+  --keep-workdir       Не очищать profile/work/out перед сборкой.
+  --profile-name NAME  Имя временного профиля (default: archflux).
+  --workdir PATH       Каталог рабочей директории mkarchiso.
+  --outdir PATH        Каталог для готового ISO.
+  --template PATH      Путь к шаблону archiso (releng).
+  -h, --help           Показать справку.
+
+Также можно использовать переменные окружения:
+  PROFILE_NAME, WORKDIR, OUTDIR, SRCTEMPLATE, KEEP_WORKDIR
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-workdir)
+      KEEP_WORKDIR=1
+      shift
+      ;;
+    --profile-name)
+      PROFILE_NAME="$2"
+      shift 2
+      ;;
+    --workdir)
+      WORKDIR="$2"
+      shift 2
+      ;;
+    --outdir)
+      OUTDIR="$2"
+      shift 2
+      ;;
+    --template)
+      SRCTEMPLATE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Неизвестный аргумент: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v pacman >/dev/null 2>&1; then
+  echo "Ошибка: pacman не найден. Запустите скрипт в Arch Linux/контейнере Arch." >&2
+  exit 1
+fi
+
+if [[ ! -d "$SRCTEMPLATE" ]]; then
+  echo "Ошибка: шаблон archiso не найден: $SRCTEMPLATE" >&2
+  exit 1
 fi
 
 if ! command -v mkarchiso >/dev/null 2>&1; then
@@ -22,7 +84,10 @@ if ! command -v mkarchiso >/dev/null 2>&1; then
 fi
 
 # Подготовка рабочей копии профиля
-rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
+if [[ "$KEEP_WORKDIR" != "1" ]]; then
+  rm -rf "$PROFILE_NAME" "$WORKDIR" "$OUTDIR"
+fi
+
 cp -r "$SRCTEMPLATE" "$PROFILE_NAME"
 
 # Подменяем packages.x86_64 на наш (если существует)
@@ -36,9 +101,12 @@ if [[ -d "airootfs" ]]; then
   cp -r airootfs "$PROFILE_NAME"/airootfs
 fi
 
-# Опционально: добавьте свои файлы в isolinux/efi, загрузочные скрипты и др.
-
 echo "Запускаю сборку ISO (mkarchiso)..."
 $SUDO mkarchiso -v -w "$WORKDIR" -o "$OUTDIR" "$PROFILE_NAME"
 
-echo "Готово. Результат в: $OUTDIR"
+latest_iso="$(find "$OUTDIR" -maxdepth 1 -type f -name '*.iso' | sort | tail -n 1 || true)"
+if [[ -n "$latest_iso" ]]; then
+  echo "Готово. ISO: $latest_iso"
+else
+  echo "Готово. Результат в: $OUTDIR"
+fi


### PR DESCRIPTION
### Motivation

- Make the ISO build workflow more user-friendly by adding CLI options and help output to the build script. 
- Allow reproducible builds in varied environments (local or container) by exposing `WORKDIR`/`OUTDIR`/`SRCTEMPLATE` configuration via CLI and environment variables. 
- Prevent accidental workspace deletion and improve post-build feedback by adding a keep-workdir option and printing the produced ISO path.

### Description

- Enhanced `scripts/build.sh` to accept CLI options `--profile-name`, `--workdir`, `--outdir`, `--template`, and `--keep-workdir`, and added a `--help` usage message. 
- Added environment validation to `scripts/build.sh` to check for `pacman` and the existence of the `SRCTEMPLATE` path before attempting the build. 
- Implemented `KEEP_WORKDIR` handling so `PROFILE_NAME`, `WORKDIR`, and `OUTDIR` are not removed when `--keep-workdir` is used, and preserved behaviour of copying the archiso template and overlays (`packages.x86_64`, `airootfs`). 
- Improved post-build reporting by locating and printing the path to the most recent `.iso` in `OUTDIR` when available, and updated `README.md` with examples and environment variable documentation.

### Testing

- Ran `bash -n scripts/build.sh` to validate script syntax, which succeeded. 
- Ran `./scripts/build.sh --help` to verify the usage output, which printed the expected help text. 
- Ran `./scripts/build.sh --template /nonexistent` in the current (non-Arch) environment which produced the expected failure message about missing `pacman`, demonstrating the new environment checks are active.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f56fea048325a4e971a80621de7e)